### PR TITLE
feat(threads): alarm clock 구현

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -29,6 +29,17 @@ static bool too_many_loops (unsigned loops);
 static void busy_wait (int64_t loops);
 static void real_time_sleep (int64_t num, int32_t denom);
 
+static struct list sleep_list;
+static bool
+sleep_less (const struct list_elem *a,
+            const struct list_elem *b,
+            void *aux UNUSED/*Pintos list 비교 함수 규격 때문에 반드시 받아야 하는 인자다.*/) {
+	struct thread *ta = list_entry (a, struct thread, elem);
+	struct thread *tb = list_entry (b, struct thread, elem);
+
+	return ta->wakeup_tick < tb->wakeup_tick;
+}
+
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
    interrupt PIT_FREQ times per second, and registers the
    corresponding interrupt. */
@@ -41,6 +52,7 @@ timer_init (void) {
 	outb (0x43, 0x34);    /* CW: counter 0, LSB then MSB, mode 2, binary. */
 	outb (0x40, count & 0xff);
 	outb (0x40, count >> 8);
+	list_init (&sleep_list);
 
 	intr_register_ext (0x20, timer_interrupt, "8254 Timer");
 }
@@ -90,11 +102,16 @@ timer_elapsed (int64_t then) {
 /* Suspends execution for approximately TICKS timer ticks. */
 void
 timer_sleep (int64_t ticks) {
-	int64_t start = timer_ticks ();
-
+	if (ticks <= 0)return;
 	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+	struct thread *cur = thread_current ();//현재 실행중인 스레드 이름을 불러와 저장 이유는 다른 스레드,테스트에서도 이 함수를 호출하기때문
+	enum intr_level old_level = intr_disable ();
+
+	cur->wakeup_tick = timer_ticks () + ticks;
+	list_insert_ordered (&sleep_list, &cur->elem, sleep_less, NULL);
+	thread_block ();//현재 스레드를 잠시 실행 불가능한 상태로 만들고 바로 scheduler로 넘기는 함수
+
+	intr_set_level (old_level);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -125,6 +142,15 @@ timer_print_stats (void) {
 static void
 timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
+	while (!list_empty (&sleep_list)) {
+		struct thread *t = list_entry (list_front (&sleep_list),struct thread, elem); //1. sleep_list 맨 앞 스레드를 t로 가져옴
+
+		if (t->wakeup_tick > ticks) //2. t->wakeup_tick이 현재 ticks보다 크면 → 아직 깨어날 시간이 아님
+			break;					//3. sleep_list는 wakeup_tick 순서로 정렬되어 있음
+									//4. 그래서 맨 앞이 아직 아니면 뒤쪽 스레드들도 전부 아직 아님
+		list_pop_front (&sleep_list);
+		thread_unblock (t);
+	}
 	thread_tick ();
 }
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,7 +91,7 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
-
+	int64_t wakeup_tick;
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 

--- a/pintos/threads/init.c
+++ b/pintos/threads/init.c
@@ -38,15 +38,15 @@
 #include "filesys/fsutil.h"
 #endif
 
-/* Page-map-level-4 with kernel mappings only. */
+/* 커널 매핑만 담는 Page Map Level 4. */
 uint64_t *base_pml4;
 
 #ifdef FILESYS
-/* -f: Format the file system? */
+/* -f: 파일 시스템을 포맷할지 여부. */
 static bool format_filesys;
 #endif
 
-/* -q: Power off after kernel tasks complete? */
+/* -q: 커널 작업이 끝난 뒤 전원을 끌지 여부. */
 bool power_off_when_done;
 
 bool thread_tests;
@@ -64,85 +64,84 @@ static void print_stats (void);
 
 int main (void) NO_RETURN;
 
-/* Pintos main program. */
+/* Pintos 메인 프로그램. */
 int
 main (void) {
 	uint64_t mem_end;
 	char **argv;
 
-	/* Clear BSS and get machine's RAM size. */
-	bss_init ();
+	/* BSS 영역을 0으로 초기화한다. */
+	bss_init ();                     /* 초기값이 0인 전역/static 변수 영역 초기화. */
 
-	/* Break command line into arguments and parse options. */
-	argv = read_command_line ();
-	argv = parse_options (argv);
+	/* 커널 명령줄을 인자로 나누고 옵션을 해석한다. */
+	argv = read_command_line ();     /* 부트로더가 넘긴 커널 명령줄 읽기. */
+	argv = parse_options (argv);     /* -q, -mlfqs 같은 실행 옵션 적용. */
 
-	/* Initialize ourselves as a thread so we can use locks,
-	   then enable console locking. */
-	thread_init ();
-	console_init ();
+	/* 현재 실행 흐름을 thread로 등록한 뒤 콘솔 lock을 켠다. */
+	thread_init ();                  /* 현재 main 실행 흐름과 thread 자료구조 초기화. */
+	console_init ();                 /* 콘솔 출력과 콘솔 lock 초기화. */
 
-	/* Initialize memory system. */
-	mem_end = palloc_init ();
-	malloc_init ();
-	paging_init (mem_end);
+	/* 메모리 시스템을 초기화한다. */
+	mem_end = palloc_init ();        /* 페이지 단위 물리 메모리 할당자 초기화. */
+	malloc_init ();                  /* 작은 크기 동적 메모리 할당자 초기화. */
+	paging_init (mem_end);           /* 커널 PML4와 가상 주소 매핑 초기화. */
 
 #ifdef USERPROG
-	tss_init ();
-	gdt_init ();
+	tss_init ();                     /* 사용자 프로그램용 TSS 초기화. */
+	gdt_init ();                     /* 사용자/커널 세그먼트용 GDT 초기화. */
 #endif
 
-	/* Initialize interrupt handlers. */
-	intr_init ();
-	timer_init ();
-	kbd_init ();
-	input_init ();
+	/* 인터럽트 처리기를 초기화한다. */
+	intr_init ();                    /* 인터럽트 디스크립터와 공통 처리 구조 초기화. */
+	timer_init ();                   /* 타이머 인터럽트 초기화. */
+	kbd_init ();                     /* 키보드 장치 초기화. */
+	input_init ();                   /* 입력 큐 초기화. */
 #ifdef USERPROG
-	exception_init ();
-	syscall_init ();
+	exception_init ();               /* 사용자 프로그램 예외 처리 초기화. */
+	syscall_init ();                 /* 시스템 콜 처리 초기화. */
 #endif
-	/* Start thread scheduler and enable interrupts. */
-	thread_start ();
-	serial_init_queue ();
-	timer_calibrate ();
+	/* thread 스케줄러를 시작하고 인터럽트를 활성화한다. */
+	thread_start ();                 /* idle thread 생성, 스케줄러 시작, 인터럽트 활성화. */
+	serial_init_queue ();            /* 시리얼 입력 큐 초기화. */
+	timer_calibrate ();              /* busy-wait 보정용 루프 횟수 측정. */
 
 #ifdef FILESYS
-	/* Initialize file system. */
-	disk_init ();
-	filesys_init (format_filesys);
+	/* 파일 시스템을 초기화한다. */
+	disk_init ();                    /* 디스크 장치 초기화. */
+	filesys_init (format_filesys);    /* 파일 시스템 초기화 및 필요 시 포맷. */
 #endif
 
 #ifdef VM
-	vm_init ();
+	vm_init ();                      /* 가상 메모리 시스템 초기화. */
 #endif
 
 	printf ("Boot complete.\n");
 
-	/* Run actions specified on kernel command line. */
+	/* 커널 명령줄에 지정된 작업을 실행한다. */
 	run_actions (argv);
 
-	/* Finish up. */
+	/* 마무리한다. */
 	if (power_off_when_done)
 		power_off ();
 	thread_exit ();
 }
 
-/* Clear BSS */
+/* BSS 영역을 지운다. */
 static void
 bss_init (void) {
-	/* The "BSS" is a segment that should be initialized to zeros.
-	   It isn't actually stored on disk or zeroed by the kernel
-	   loader, so we have to zero it ourselves.
+	/* BSS는 0으로 초기화되어야 하는 세그먼트다.
+	   실제로 디스크에 저장되거나 커널 로더가 0으로 채워주지 않으므로,
+	   여기서 직접 0으로 채운다.
 
-	   The start and end of the BSS segment is recorded by the
-	   linker as _start_bss and _end_bss.  See kernel.lds. */
+	   BSS 세그먼트의 시작과 끝은 링커가 _start_bss와 _end_bss로
+	   기록한다. kernel.lds를 참고한다. */
 	extern char _start_bss, _end_bss;
 	memset (&_start_bss, 0, &_end_bss - &_start_bss);
 }
 
-/* Populates the page table with the kernel virtual mapping,
- * and then sets up the CPU to use the new page directory.
- * Points base_pml4 to the pml4 it creates. */
+/* page table에 커널 가상 주소 매핑을 채우고,
+ * CPU가 새 page directory를 사용하도록 설정한다.
+ * base_pml4가 새로 만든 pml4를 가리키게 한다. */
 static void
 paging_init (uint64_t mem_end) {
 	uint64_t *pml4, *pte;
@@ -150,8 +149,8 @@ paging_init (uint64_t mem_end) {
 	pml4 = base_pml4 = palloc_get_page (PAL_ASSERT | PAL_ZERO);
 
 	extern char start, _end_kernel_text;
-	// Maps physical address [0 ~ mem_end] to
-	//   [LOADER_KERN_BASE ~ LOADER_KERN_BASE + mem_end].
+	// 물리 주소 [0 ~ mem_end]를
+	//   [LOADER_KERN_BASE ~ LOADER_KERN_BASE + mem_end]에 매핑한다.
 	for (uint64_t pa = 0; pa < mem_end; pa += PGSIZE) {
 		uint64_t va = (uint64_t) ptov(pa);
 
@@ -163,12 +162,11 @@ paging_init (uint64_t mem_end) {
 			*pte = pa | perm;
 	}
 
-	// reload cr3
+	// cr3를 다시 로드한다.
 	pml4_activate(0);
 }
 
-/* Breaks the kernel command line into words and returns them as
-   an argv-like array. */
+/* 커널 명령줄을 단어 단위로 나누어 argv와 비슷한 배열로 반환한다. */
 static char **
 read_command_line (void) {
 	static char *argv[LOADER_ARGS_LEN / 2 + 1];
@@ -188,7 +186,7 @@ read_command_line (void) {
 	}
 	argv[argc] = NULL;
 
-	/* Print kernel command line. */
+	/* 커널 명령줄을 출력한다. */
 	printf ("Kernel command line:");
 	for (i = 0; i < argc; i++)
 		if (strchr (argv[i], ' ') == NULL)
@@ -200,8 +198,7 @@ read_command_line (void) {
 	return argv;
 }
 
-/* Parses options in ARGV[]
-   and returns the first non-option argument. */
+/* ARGV[]의 옵션을 해석하고, 첫 번째 비옵션 인자를 반환한다. */
 static char **
 parse_options (char **argv) {
 	for (; *argv != NULL && **argv == '-'; argv++) {
@@ -234,7 +231,7 @@ parse_options (char **argv) {
 	return argv;
 }
 
-/* Runs the task specified in ARGV[1]. */
+/* ARGV[1]에 지정된 작업을 실행한다. */
 static void
 run_task (char **argv) {
 	const char *task = argv[1];
@@ -252,18 +249,17 @@ run_task (char **argv) {
 	printf ("Execution of '%s' complete.\n", task);
 }
 
-/* Executes all of the actions specified in ARGV[]
-   up to the null pointer sentinel. */
+/* ARGV[]에 지정된 모든 작업을 NULL 포인터 표시까지 실행한다. */
 static void
 run_actions (char **argv) {
-	/* An action. */
+	/* 하나의 작업. */
 	struct action {
-		char *name;                       /* Action name. */
-		int argc;                         /* # of args, including action name. */
-		void (*function) (char **argv);   /* Function to execute action. */
+		char *name;                       /* 작업 이름. */
+		int argc;                         /* 작업 이름을 포함한 인자 수. */
+		void (*function) (char **argv);   /* 작업을 실행할 함수. */
 	};
 
-	/* Table of supported actions. */
+	/* 지원하는 작업 목록. */
 	static const struct action actions[] = {
 		{"run", 2, run_task},
 #ifdef FILESYS
@@ -280,27 +276,26 @@ run_actions (char **argv) {
 		const struct action *a;
 		int i;
 
-		/* Find action name. */
+		/* 작업 이름을 찾는다. */
 		for (a = actions; ; a++)
 			if (a->name == NULL)
 				PANIC ("unknown action `%s' (use -h for help)", *argv);
 			else if (!strcmp (*argv, a->name))
 				break;
 
-		/* Check for required arguments. */
+		/* 필요한 인자가 있는지 확인한다. */
 		for (i = 1; i < a->argc; i++)
 			if (argv[i] == NULL)
 				PANIC ("action `%s' requires %d argument(s)", *argv, a->argc - 1);
 
-		/* Invoke action and advance. */
+		/* 작업을 호출하고 다음 작업으로 이동한다. */
 		a->function (argv);
 		argv += a->argc;
 	}
 
 }
 
-/* Prints a kernel command line help message and powers off the
-   machine. */
+/* 커널 명령줄 도움말을 출력하고 머신의 전원을 끈다. */
 static void
 usage (void) {
 	printf ("\nCommand line syntax: [OPTION...] [ACTION...]\n"
@@ -334,8 +329,7 @@ usage (void) {
 }
 
 
-/* Powers down the machine we're running on,
-   as long as we're running on Bochs or QEMU. */
+/* Bochs 또는 QEMU에서 실행 중이면 현재 머신의 전원을 끈다. */
 void
 power_off (void) {
 #ifdef FILESYS
@@ -345,11 +339,11 @@ power_off (void) {
 	print_stats ();
 
 	printf ("Powering off...\n");
-	outw (0x604, 0x2000);               /* Poweroff command for qemu */
+	outw (0x604, 0x2000);               /* QEMU 전원 종료 명령. */
 	for (;;);
 }
 
-/* Print statistics about Pintos execution. */
+/* Pintos 실행 통계를 출력한다. */
 static void
 print_stats (void) {
 	timer_print_stats ();


### PR DESCRIPTION
## 작업 내용

- `timer_sleep()`의 busy waiting 방식을 sleep/block 기반으로 변경
- 잠든 thread를 관리하기 위한 `sleep_list` 추가
- 각 thread의 깨어날 시점을 저장하는 `wakeup_tick` 필드 추가
- `timer_interrupt()`에서 깨어날 시간이 된 thread를 unblock하도록 구현

## 테스트

- `make tests/threads/alarm-single.result`
- `make tests/threads/alarm-multiple.result`
- `make tests/threads/alarm-simultaneous.result`
- `make tests/threads/alarm-priority`
- `make tests/threads/alarm-zero.result`
- `make tests/threads/alarm-negative.result`

모두 통과
Closed #12 
Closed #13 
Closed #14 
Closed #15
Closed #16 
Closed #17 