### PR TITLE
[Project1] Priority Scheduling 구현

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -150,6 +150,8 @@ timer_interrupt (struct intr_frame *args UNUSED) {
 									//4. 그래서 맨 앞이 아직 아니면 뒤쪽 스레드들도 전부 아직 아님
 		list_pop_front (&sleep_list);
 		thread_unblock (t);
+		if (t->priority > thread_current ()->priority)
+			intr_yield_on_return ();
 	}
 	thread_tick ();
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -121,15 +121,27 @@ sema_try_down (struct semaphore *sema) {
 void
 sema_up (struct semaphore *sema) {
 	enum intr_level old_level;
+	struct thread *unblocked = NULL;
 
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+
+	if (!list_empty (&sema->waiters)) {
+		unblocked = list_entry (list_pop_front (&sema->waiters),
+		                        struct thread, elem);
+		thread_unblock (unblocked);
+	}
+
 	sema->value++;
 	intr_set_level (old_level);
+
+	if (unblocked != NULL && unblocked->priority > thread_current ()->priority) {
+		if (intr_context ())
+			intr_yield_on_return ();
+		else
+			thread_yield ();
+	}
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -43,7 +43,15 @@
    thread, if any). */
 
 static bool
-thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *aux UNUSED);
+thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *aux UNUSED) 
+{
+	struct thread *ta = list_entry (a, struct thread, elem);
+	struct thread *tb = list_entry (b, struct thread, elem);
+
+	return ta->priority > tb->priority;
+}
+
+
 
 
 
@@ -64,15 +72,6 @@ sema_init (struct semaphore *sema, unsigned value) {
    interrupts disabled, but if it sleeps then the next scheduled
    thread will probably turn interrupts back on. This is
    sema_down function. */
-
-static bool
-thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *aux UNUSED) 
-{
-	struct thread *ta = list_entry (a, struct thread, elem);
-	struct thread *tb = list_entry (b, struct thread, elem);
-
-	return ta->priority > tb->priority;
-}
 
 void
 sema_down (struct semaphore *sema) {
@@ -259,6 +258,20 @@ struct semaphore_elem {
 	struct semaphore semaphore;         /* This semaphore. */
 };
 
+static bool
+cond_priority_more (const struct list_elem *a, const struct list_elem *b,void *aux UNUSED) 
+{
+	struct semaphore_elem *sa = list_entry (a, struct semaphore_elem, elem);
+	struct semaphore_elem *sb = list_entry (b, struct semaphore_elem, elem);
+
+	struct thread *ta = list_entry (list_front (&sa->semaphore.waiters),
+	                                struct thread, elem);
+	struct thread *tb = list_entry (list_front (&sb->semaphore.waiters),
+	                                struct thread, elem);
+
+	return ta->priority > tb->priority;
+}
+
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
    code to receive the signal and act upon it. */
@@ -319,9 +332,10 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+	if (!list_empty (&cond->waiters)) {
+		list_sort (&cond->waiters, cond_priority_more, NULL);
+		sema_up (&list_entry (list_pop_front (&cond->waiters),struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -41,6 +41,13 @@
 
    - up or "V": increment the value (and wake up one waiting
    thread, if any). */
+
+static bool
+thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *aux UNUSED);
+
+
+
+
 void
 sema_init (struct semaphore *sema, unsigned value) {
 	ASSERT (sema != NULL);
@@ -57,6 +64,16 @@ sema_init (struct semaphore *sema, unsigned value) {
    interrupts disabled, but if it sleeps then the next scheduled
    thread will probably turn interrupts back on. This is
    sema_down function. */
+
+static bool
+thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *aux UNUSED) 
+{
+	struct thread *ta = list_entry (a, struct thread, elem);
+	struct thread *tb = list_entry (b, struct thread, elem);
+
+	return ta->priority > tb->priority;
+}
+
 void
 sema_down (struct semaphore *sema) {
 	enum intr_level old_level;
@@ -66,7 +83,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+	list_insert_ordered (&sema->waiters,&thread_current ()->elem,thread_priority_more,NULL);
 		thread_block ();
 	}
 	sema->value--;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -212,6 +212,8 @@ thread_create (const char *name, int priority,
 
 	/* Add to run queue. */
 	thread_unblock (t);
+	if (t->priority > thread_current ()->priority)
+		thread_yield ();
 
 	return tid;
 }
@@ -241,8 +243,6 @@ thread_block (void) {
 void
 thread_unblock (struct thread *t) {
 	enum intr_level old_level;
-	bool should_yield = false;
-	struct thread *curt = thread_current ();
 
 	ASSERT (is_thread (t));
 
@@ -250,16 +250,8 @@ thread_unblock (struct thread *t) {
 	ASSERT (t->status == THREAD_BLOCKED);
 	list_push_back (&ready_queues[t->priority], &t->elem);
 	t->status = THREAD_READY;
-	if (t->priority > curt->priority)should_yield = true;
-	
 	intr_set_level (old_level);
 
-	if (should_yield) {
-		if (intr_context ())
-			intr_yield_on_return ();
-		else
-			thread_yield ();
-	}
 }
 
 /* Returns the name of the running thread. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -26,7 +26,7 @@
 
 /* List of processes in THREAD_READY state, that is, processes
    that are ready to run but not actually running. */
-static struct list ready_list;
+static struct list ready_queues[PRI_MAX + 1];
 
 /* Idle thread. */
 static struct thread *idle_thread;
@@ -107,7 +107,11 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
-	list_init (&ready_list);
+	for (int i = PRI_MIN; i <= PRI_MAX; i++)
+	{
+		list_init (&ready_queues[i]);
+	}
+	
 	list_init (&destruction_req);
 
 	/* Set up a thread structure for the running thread. */
@@ -240,7 +244,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_push_back (&ready_queues[t->priority], &t->elem);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -303,7 +307,7 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		list_push_back (&ready_queues[curr->priority], &curr->elem);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
@@ -418,10 +422,14 @@ init_thread (struct thread *t, const char *name, int priority) {
    idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
-	if (list_empty (&ready_list))
-		return idle_thread;
-	else
-		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	for (int priority = PRI_MAX; priority >= PRI_MIN; priority--) {
+		if (!list_empty (&ready_queues[priority])) {
+			return list_entry (list_pop_front (&ready_queues[priority]),
+			                   struct thread, elem);
+		}
+	}
+
+	return idle_thread;
 }
 
 /* Use iretq to launch the thread */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -62,6 +62,8 @@ static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
+static bool has_higher_ready_thread (void);
+
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -239,6 +241,8 @@ thread_block (void) {
 void
 thread_unblock (struct thread *t) {
 	enum intr_level old_level;
+	bool should_yield = false;
+	struct thread *curt = thread_current ();
 
 	ASSERT (is_thread (t));
 
@@ -246,7 +250,16 @@ thread_unblock (struct thread *t) {
 	ASSERT (t->status == THREAD_BLOCKED);
 	list_push_back (&ready_queues[t->priority], &t->elem);
 	t->status = THREAD_READY;
+	if (t->priority > curt->priority)should_yield = true;
+	
 	intr_set_level (old_level);
+
+	if (should_yield) {
+		if (intr_context ())
+			intr_yield_on_return ();
+		else
+			thread_yield ();
+	}
 }
 
 /* Returns the name of the running thread. */
@@ -316,6 +329,8 @@ thread_yield (void) {
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
+	if (has_higher_ready_thread ())thread_yield ();
+	
 }
 
 /* Returns the current thread's priority. */
@@ -431,6 +446,19 @@ next_thread_to_run (void) {
 
 	return idle_thread;
 }
+
+static bool
+has_higher_ready_thread (void) {
+	int current_priority = thread_current ()->priority;
+
+	for (int priority = PRI_MAX; priority > current_priority; priority--) {
+		if (!list_empty (&ready_queues[priority]))
+			return true;
+	}
+
+	return false;
+}
+
 
 /* Use iretq to launch the thread */
 void


### PR DESCRIPTION
## 변경 내용

- ready_list를 priority별 ready_queues로 변경
- thread 생성, yield, unblock 시 priority queue 기준으로 READY thread 관리
- scheduler가 가장 높은 priority queue에서 다음 thread를 선택하도록 수정
- 현재 thread보다 높은 priority thread가 READY가 되면 선점하도록 처리
- semaphore waiters를 priority 순서로 관리
- condition variable signal 시 가장 높은 priority waiter를 깨우도록 수정
- alarm sleep에서 깨어난 thread가 더 높은 priority면 interrupt return 시점에 yield 예약

## 구현 의도

Project 1 Day2의 priority scheduling 요구사항을 만족하기 위해,
READY thread와 synchronization waiters가 priority 기준으로 동작하도록 수정했습니다.

`thread_unblock()`은 READY queue 삽입만 담당하게 하고,
실제 선점 판단은 `thread_create()`, `sema_up()`, `timer_interrupt()`처럼
호출자의 후처리가 끝난 지점에서 수행하도록 분리했습니다.

## 테스트

- priority-change PASS
- priority-fifo PASS
- priority-preempt PASS
- priority-sema PASS
- priority-condvar PASS

Closed #18 
Closed #25 
Closed #26
Closed #27 
Closed #28 
