### PR TITLE
feat(threads): priority donation 중첩 전파 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,9 +91,13 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int base_priority;
 	int64_t wakeup_tick;
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
+	struct lock *wait_lock;
+	struct list donations;
+	struct list_elem donation_elem;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/tests/threads/priority-donate-chain.c
+++ b/pintos/tests/threads/priority-donate-chain.c
@@ -45,7 +45,7 @@ void
 test_priority_donate_chain (void) 
 {
   int i;  
-  struct lock locks[NESTING_DEPTH - 1];
+  struct lock locks[NESTING_DEPTH - 1]; // 주소값
   struct lock_pair lock_pairs[NESTING_DEPTH];
 
   /* This test does not work with the MLFQS. */

--- a/pintos/tests/threads/priority-donate-nest.c
+++ b/pintos/tests/threads/priority-donate-nest.c
@@ -28,7 +28,7 @@ void
 test_priority_donate_nest (void) 
 {
   struct lock a, b;
-  struct locks locks;
+  struct locks locks; // thread_create 인자로
 
   /* This test does not work with the MLFQS. */
   ASSERT (!thread_mlfqs);
@@ -72,10 +72,10 @@ medium_thread_func (void *locks_)
        PRI_DEFAULT + 2, thread_get_priority ());
   msg ("Medium thread got the lock.");
 
-  lock_release (locks->a);
+  lock_release (locks->a); // a 
   thread_yield ();
 
-  lock_release (locks->b);
+  lock_release (locks->b); //
   thread_yield ();
 
   msg ("High thread should have just finished.");

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -51,10 +51,19 @@ thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *
 	return ta->priority > tb->priority;
 }
 
+void
+donation_thread(void) {
 
+	struct thread *cur_thd = thread_current();
+	struct lock *lock = cur_thd->wait_lock;
 
-
-
+	while(lock != NULL && lock->holder != NULL) {
+		if(lock->holder->priority >= cur_thd->priority){
+			break;
+		}
+		lock->holder->priority = cur_thd->priority;
+	}
+}
 
 void
 sema_init (struct semaphore *sema, unsigned value) {
@@ -216,8 +225,17 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+	struct thread *cur_thd = thread_current();
+
+	if(lock->holder != NULL) {
+		cur_thd->wait_lock = lock;
+		list_push_back(&lock->holder->donations, &cur_thd->donation_elem);
+		donation_thread();
+	}
+
 	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	cur_thd->wait_lock = NULL;
+	lock->holder = cur_thd;
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -250,6 +268,29 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	// 현 스레드 priority 다시 계산
+	struct thread *cur_thd = thread_current(); 
+	struct list_elem *e = list_begin(&cur_thd->donations);
+	while( e != list_end(&cur_thd->donations)) {
+		struct thread *donor = list_entry (e, struct thread, donation_elem);
+		struct list_elem *next = list_next(e);
+
+		if(donor->wait_lock == lock) list_remove(e);
+
+		e = next;
+	}
+	if(lock->holder != NULL && lock->holder == cur_thd) {
+		cur_thd->priority = cur_thd->base_priority;
+
+		for (e = list_begin (&cur_thd->donations);
+     		e != list_end (&cur_thd->donations);
+     e = list_next (e)) {
+    struct thread *donor = list_entry (e, struct thread, donation_elem);
+
+    if (donor->priority > cur_thd->priority)
+        cur_thd->priority = donor->priority;
+}
+
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }
@@ -263,6 +304,8 @@ lock_held_by_current_thread (const struct lock *lock) {
 
 	return lock->holder == thread_current ();
 }
+
+
 
 /* One semaphore in a list. */
 struct semaphore_elem {

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -54,14 +54,19 @@ thread_priority_more (const struct list_elem *a,const struct list_elem *b,void *
 void
 donation_thread(void) {
 
-	struct thread *cur_thd = thread_current();
-	struct lock *lock = cur_thd->wait_lock;
+	struct thread *cur_thd = thread_current(); // high
+	struct lock *lock = cur_thd->wait_lock; // b
 
 	while(lock != NULL && lock->holder != NULL) {
-		if(lock->holder->priority >= cur_thd->priority){
+		struct thread *holder = lock->holder; // me // main
+
+		if(holder->priority >= cur_thd->priority){
 			break;
 		}
-		lock->holder->priority = cur_thd->priority;
+		holder->priority = cur_thd->priority; // 32 = 33
+
+		cur_thd = holder; // hi = me // me = main
+		lock = cur_thd->wait_lock; // a // NULL
 	}
 }
 
@@ -223,11 +228,11 @@ void
 lock_acquire (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
-	ASSERT (!lock_held_by_current_thread (lock));
+	ASSERT (!lock_held_by_current_thread (lock)); //ㅁㅁㅁㅁ
 
-	struct thread *cur_thd = thread_current();
+	struct thread *cur_thd = thread_current(); // high
 
-	if(lock->holder != NULL) {
+	if(lock->holder != NULL) { // me
 		cur_thd->wait_lock = lock;
 		list_push_back(&lock->holder->donations, &cur_thd->donation_elem);
 		donation_thread();
@@ -237,7 +242,7 @@ lock_acquire (struct lock *lock) {
 	cur_thd->wait_lock = NULL;
 	lock->holder = cur_thd;
 }
-
+ 
 /* Tries to acquires LOCK and returns true if successful or false
    on failure.  The lock must not already be held by the current
    thread.
@@ -265,31 +270,32 @@ lock_try_acquire (struct lock *lock) {
    handler. */
 void
 lock_release (struct lock *lock) {
-	ASSERT (lock != NULL);
+	ASSERT (lock != NULL); // a
 	ASSERT (lock_held_by_current_thread (lock));
 
 	// 현 스레드 priority 다시 계산
-	struct thread *cur_thd = thread_current(); 
-	struct list_elem *e = list_begin(&cur_thd->donations);
-	while( e != list_end(&cur_thd->donations)) {
-		struct thread *donor = list_entry (e, struct thread, donation_elem);
-		struct list_elem *next = list_next(e);
+	struct thread *cur_thd = thread_current(); // main
+	struct list_elem *e = list_begin(&cur_thd->donations);// Medium
+	while( e != list_end(&cur_thd->donations)) { 
+		struct thread *donor = list_entry (e, struct thread, donation_elem); // me
+		struct list_elem *next = list_next(e); // end
 
-		if(donor->wait_lock == lock) list_remove(e);
+		if(donor->wait_lock == lock) list_remove(e); // me
 
 		e = next;
 	}
 	if(lock->holder != NULL && lock->holder == cur_thd) {
-		cur_thd->priority = cur_thd->base_priority;
+		cur_thd->priority = cur_thd->base_priority; // 31
 
 		for (e = list_begin (&cur_thd->donations);
      		e != list_end (&cur_thd->donations);
-     e = list_next (e)) {
-    struct thread *donor = list_entry (e, struct thread, donation_elem);
+			e = list_next (e)) {
+			struct thread *donor = list_entry (e, struct thread, donation_elem);
 
-    if (donor->priority > cur_thd->priority)
-        cur_thd->priority = donor->priority;
-}
+			if (donor->priority > cur_thd->priority)
+				cur_thd->priority = donor->priority;
+			}
+	}
 
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -320,6 +320,11 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
+
+	struct thread *cur_thd = thread_current();
+	
+
+	
 	thread_current ()->priority = new_priority;
 	if (has_higher_ready_thread ())thread_yield ();
 	
@@ -419,6 +424,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	strlcpy (t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
+	t->base_priority = priority;
 	t->magic = THREAD_MAGIC;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -323,9 +323,7 @@ thread_set_priority (int new_priority) {
 
 	struct thread *cur_thd = thread_current();
 	
-
-	
-	thread_current ()->priority = new_priority;
+	cur_thd->base_priority = new_priority;
 	if (has_higher_ready_thread ())thread_yield ();
 	
 }
@@ -426,6 +424,8 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->priority = priority;
 	t->base_priority = priority;
 	t->magic = THREAD_MAGIC;
+	t->wait_lock = NULL;
+	list_init(&t->donations);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should


### PR DESCRIPTION
- lock 대기 시 현재 스레드의 wait_lock을 설정하고 lock 보유자에게 priority donation 수행
- donation_thread()를 통해 lock 의존 관계를 따라 중첩 donation 전파
- lock release 시 해당 lock으로부터 발생한 donation을 제거하고 base_priority 기준으로 priority 재계산
- thread 초기화 시 base_priority, wait_lock, donations 목록 초기화
- thread_set_priority()가 base_priority를 갱신하도록 수정
- semaphore waiters를 priority 기준으로 정렬하고 높은 priority 스레드 unblock 시 yield 처리

Closed #19 
Closed #20 
Closed #21 
Closed #22 
Closed #24 
Closed #29 
