### PR TITLE
feat: Argument Passing

### DIFF
--- a/pintos/include/threads/interrupt.h
+++ b/pintos/include/threads/interrupt.h
@@ -22,16 +22,16 @@ struct gp_registers {
 	uint64_t r13;
 	uint64_t r12;
 	uint64_t r11;
-	uint64_t r10;
-	uint64_t r9;
-	uint64_t r8;
-	uint64_t rsi;
-	uint64_t rdi;
+	uint64_t r10;															// argu 4
+	uint64_t r9;															// argu 5
+	uint64_t r8;															// argu 6
+	uint64_t rsi;															// argu 2
+	uint64_t rdi;															// argu 1 
 	uint64_t rbp;
-	uint64_t rdx;
+	uint64_t rdx;															// argu 3
 	uint64_t rcx;
 	uint64_t rbx;
-	uint64_t rax;
+	uint64_t rax;															// 반환값 , syscall result
 } __attribute__((packed));
 
 struct intr_frame {
@@ -52,12 +52,12 @@ struct intr_frame {
 	uint64_t error_code;
 /* Pushed by the CPU.
    These are the interrupted task's saved registers. */
-	uintptr_t rip;
+	uintptr_t rip;															// 프로그램 시작 주소
 	uint16_t cs;
 	uint16_t __pad5;
 	uint32_t __pad6;
 	uint64_t eflags;
-	uintptr_t rsp;
+	uintptr_t rsp;															// 유저 스택 시작 위치 ( Crash )
 	uint16_t ss;
 	uint16_t __pad7;
 	uint32_t __pad8;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -45,6 +45,7 @@ process_create_initd (const char *file_name) {
 
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */
+	// 단일 페이지를 얻어서 반환 
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
@@ -168,7 +169,9 @@ process_exec (void *f_name) {
 	/* We cannot use the intr_frame in the thread structure.
 	 * This is because when current thread rescheduled,
 	 * it stores the execution information to the member. */
-	struct intr_frame _if;
+	
+	 // 인터럽트(or System call) 발생 순간의 CPU 상태 스냅샷
+	 struct intr_frame _if;
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
@@ -335,10 +338,39 @@ load (const char *file_name, struct intr_frame *if_) {
 		goto done;
 	process_activate (thread_current ());
 
+	// seperate argv
+	if(file_name == NULL) goto done;
+	char *fn_copy_parse;
+
+	// 원본 보호를 위한 복사본 생성
+	fn_copy_parse = palloc_get_page (0);
+	if(fn_copy_parse == NULL) {
+		goto done;
+	}
+	strlcpy(fn_copy_parse, file_name, PGSIZE);
+
+	char *save_pt; //
+	char *argv[64] = {0}; // 앞서 pintos 기준이 4kb로 읽고, 넉넉하게 포인터배열 64개(512byte) + 나머지 문자열 크기
+	int argc = 0;
+
+	// 첫번째 토큰이 없다면
+	char *ftken;
+
+	// 
+	for(ftken = strtok_r(fn_copy_parse, " ", &save_pt);
+		ftken != NULL;
+		ftken = strtok_r(NULL, " ", &save_pt)) {
+			if(argc > 62) goto done;
+			argv[argc] = ftken;
+			argc++;
+		}
+	if(argv[0] == NULL) goto done;
+
+
 	/* Open executable file. */
-	file = filesys_open (file_name);
+	file = filesys_open (argv[0]);
 	if (file == NULL) {
-		printf ("load: %s: open failed\n", file_name);
+		printf ("load: %s: open failed\n", argv[0]);
 		goto done;
 	}
 
@@ -350,7 +382,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			|| ehdr.e_version != 1
 			|| ehdr.e_phentsize != sizeof (struct Phdr)
 			|| ehdr.e_phnum > 1024) {
-		printf ("load: %s: error loading executable\n", file_name);
+		printf ("load: %s: error loading executable\n", argv[0]);
 		goto done;
 	}
 
@@ -413,15 +445,33 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
+	
+	char* user_argv[64] = {0};
+	user_argv[argc] = NULL;
+	// 스택 주소에 null 넣을꺼없이 여기서 미리 넣음
 
+	int stk_argc = argc;
+	while(stk_argc > 0) {
+		size_t size = (strlen(argv[stk_argc-1])+1);
+		if_->rsp -= size;
+
+		memcpy((void*)if_->rsp, argv[stk_argc-1], size);
+		user_argv[stk_argc-1] = (void*)if_->rsp;
+		stk_argc--;
+		
+	}
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+	
+	if_->R.rdi = argc;
+	if_->R.rsi = if_->rsp;
 
 	success = true;
 
 done:
 	/* We arrive here whether the load is successful or not. */
 	file_close (file);
+	palloc_free_page(fn_copy_parse); // argv에는 fn_copy_parse의 주소값이 들어가기에 스택에 올리고 나서 해제해야함
 	return success;
 }
 
@@ -537,14 +587,20 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
 setup_stack (struct intr_frame *if_) {
+	// 8비트 정수
 	uint8_t *kpage;
 	bool success = false;
 
+	// 페이지 할당
 	kpage = palloc_get_page (PAL_USER | PAL_ZERO);
 	if (kpage != NULL) {
+		
+		// 커널에서 가져온(kpage) 수정할 수 있는(true) 페이지를 첫번째 인자에 매핑
 		success = install_page (((uint8_t *) USER_STACK) - PGSIZE, kpage, true);
 		if (success)
+			// 인터럽트 프레임(if)에서 rsp(스택 포인터)를 USER_STACK으로 변경
 			if_->rsp = USER_STACK;
+			//// 프로그램 시작 시 사용할 스택의 시작위치 저장
 		else
 			palloc_free_page (kpage);
 	}

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -41,21 +41,28 @@ process_init (void) {
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
+	char *name_copy;
+	char *save_ptr;
 	tid_t tid;
 
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */
 	// 단일 페이지를 얻어서 반환 
 	fn_copy = palloc_get_page (0);
+	name_copy = palloc_get_page(0);
+
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
+	strlcpy (name_copy, file_name, PGSIZE);
 
 	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
+	tid = thread_create (strtok_r(name_copy, " ", &save_ptr), PRI_DEFAULT, initd, fn_copy);
+	palloc_free_page(name_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
 	return tid;
+	
 }
 
 /* A thread function that launches first user process. */
@@ -207,7 +214,8 @@ process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	return -1;
+	timer_sleep(100);
+	 return -1;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
@@ -350,7 +358,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	strlcpy(fn_copy_parse, file_name, PGSIZE);
 
 	char *save_pt; //
-	char *argv[64] = {0}; // 앞서 pintos 기준이 4kb로 읽고, 넉넉하게 포인터배열 64개(512byte) + 나머지 문자열 크기
+	char **argv[64] = {0}; // 앞서 pintos 기준이 4kb로 읽고, 넉넉하게 포인터배열 64개(512byte) + 나머지 문자열 크기
 	int argc = 0;
 
 	// 첫번째 토큰이 없다면
@@ -446,35 +454,52 @@ load (const char *file_name, struct intr_frame *if_) {
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 	
-	char* user_argv[64] = {0};
-	user_argv[argc] = NULL;
-	// 스택 주소에 null 넣을꺼없이 여기서 미리 넣음
+	char *user_argv[64] = {0};
 
 	int stk_argc = argc;
 	while(stk_argc > 0) {
 		size_t size = (strlen(argv[stk_argc-1])+1);
 		if_->rsp -= size;
 
-		memcpy((void*)if_->rsp, argv[stk_argc-1], size);
-		user_argv[stk_argc-1] = (void*)if_->rsp;
+		memcpy((char *)if_->rsp, argv[stk_argc-1], size);
+		user_argv[stk_argc-1] = (char *)if_->rsp;
 		stk_argc--;
-		
 	}
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+
+	// alignment
+	while(if_->rsp % 8 != 0) {
+		if_->rsp--;
+	}
+	// if (((unsigned long long) if_->rsp & 7) != 0) {
+	// 	size_t padding = (size_t) if_-> rsp % 8;
+	// 	if_->rsp -= padding;
+	// 	memset(*(char **) if_->rsp, 0, padding);
+	// }
+	if_->rsp -= 8;
+	*(char **)if_->rsp = NULL;
+
+	// push stack (address)
+	for(int i=argc-1; i>=0; i--) {
+		if_->rsp -= sizeof(char*); // 8byte
+		*(char **)(if_->rsp) = user_argv[i];
+		// if_->rsp(유저스택주소)를 1byte char 형 포인터로 형변환
+		// char 포인터가 가리키는 메모리에 프로그램 인자 주소값 삽입
+	}
+	// push fake address
+	if_->rsp -= 8;
+	*(char **)if_->rsp = 0;
 	
 	if_->R.rdi = argc;
-	if_->R.rsi = if_->rsp;
+	if_->R.rsi = if_->rsp + 8;
 
 	success = true;
 
 done:
 	/* We arrive here whether the load is successful or not. */
 	file_close (file);
-	palloc_free_page(fn_copy_parse); // argv에는 fn_copy_parse의 주소값이 들어가기에 스택에 올리고 나서 해제해야함
+	if(fn_copy_parse != NULL) palloc_free_page(fn_copy_parse); // argv에는 fn_copy_parse의 주소값이 들어가기에 스택에 올리고 나서 해제해야함
 	return success;
 }
-
 
 /* Checks whether PHDR describes a valid, loadable segment in
  * FILE and returns true if so, false otherwise. */

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -39,8 +39,23 @@ syscall_init (void) {
 
 /* The main system call interface */
 void
-syscall_handler (struct intr_frame *f UNUSED) {
+syscall_handler (struct intr_frame *f) {
 	// TODO: Your implementation goes here.
-	printf ("system call!\n");
-	thread_exit ();
+	if(f->R.rax==SYS_EXIT)
+	{
+		int status = f->R.rdi;
+		printf("%s: exit(%d)\n", thread_current()->name, status);
+		thread_exit();
+	}
+	else if (f->R.rax==SYS_WRITE)
+	{
+		int fd = f->R.rdi;
+		const void *buffer = (const void *) f->R.rsi;
+		unsigned size = f->R.rdx;
+
+		if (fd == 1) {
+			putbuf(buffer, size);
+			f->R.rax = size;
+		}
+	}
 }


### PR DESCRIPTION
argument passing을 위한 사용자 프로그램 로딩 흐름 수정

process_create_initd() 내부에서 프로그램 이름과 전체 인자 문자열을 분리하고, load()에서 명령어를 argc/argv로 파싱해 사용자 스택에 배치하도록 구현.

실행 파일은 argv[0] 기준으로 Open, rdi/rsi에 argc와 argv 주소를 전달하도록 설정.

syscall_handler() SYS_EXIT와 stdout 대상 SYS_WRITE의 최소 동작 추가.

interrupt.h 내부 syscall 인자/반환 레지스터 의미 주석정리.

주제 연관 테스트 모두 PASS.

Closed #51 
Closed #52 
Closed #53
Closed #54  
Closed #55 
Closed #56 
Closed #57 