### PR TITLE
feat(userprog): wait 동기화를 위한 child_info 구조 추가

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -85,6 +86,15 @@ typedef int tid_t;
  * only because they are mutually exclusive: only a thread in the
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
+#ifdef USERPROG
+struct child_info {
+	tid_t tid;
+	int exit_status;
+	bool exited;
+	bool waited;
+	struct list_elem elem;
+};
+#endif
 struct lock;
 struct thread {
 	/* Owned by thread.c. */
@@ -100,9 +110,14 @@ struct thread {
 	struct list donations;         /* 나에게 donation한 thread 목록. */
 	struct list_elem donation_elem;
 
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
+
+	struct list children;
+	struct semaphore child_wait_sema;
+	struct child_info *child_info;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,6 +92,7 @@ struct child_info {
 	int exit_status;
 	bool exited;
 	bool waited;
+	struct thread *parent;
 	struct list_elem elem;
 };
 #endif

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -448,6 +448,12 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->base_priority = priority;
 	t->waiting_lock = NULL;
 	list_init (&t->donations);
+
+#ifdef USERPROG
+	list_init (&t->children);
+	sema_init (&t->child_wait_sema, 0);
+	t->child_info = NULL;
+#endif
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should


### PR DESCRIPTION
## 변경 사항
- user process의 자식 정보를 관리하기 위한 `child_info` 구조를 추가했습니다.
- 각 thread가 자식 리스트와 wait 동기화용 semaphore를 가지도록 초기화했습니다.
- child가 부모 thread를 참조할 수 있도록 parent 포인터를 추가했습니다.

## 의도
- 이후 `process_wait()` 구현에서 부모가 특정 자식의 종료를 기다릴 수 있도록 기반 구조를 준비합니다.
- `exit_status`, `exited`, `waited` 값을 통해 중복 wait과 종료 상태 전달을 처리할 수 있게 합니다.

## 변경 파일
- `pintos/include/threads/thread.h`
- `pintos/threads/thread.c`

## 테스트
- 구조체 및 초기화 코드 추가 단계라 별도 userprog wait 테스트는 아직 진행하지 않았습니다.