### PR TITLE
userprog fd 테이블 초기화 및 조회 헬퍼 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ core
 .DS_Store
 
 **/.test_status
+
+# 개인 문서 및 로컬 테스트 히스토리
+pintos/docs/
+pintos/.vscode/pintos-test-history.json

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -25,9 +25,10 @@ typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0        /* Lowest priority. */
+#define PRI_DEFAULT 31   /* Default priority. */
+#define PRI_MAX 63       /* Highest priority. */
+#define FD_MAX 128      /* 프로세스당 열 수 있는 파일 최대 개수 */
 
 /* A kernel thread or user process.
  *
@@ -114,7 +115,9 @@ struct thread {
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+	uint64_t *pml4;                 /* Page map level 4 */
+    struct file *fd_table[FD_MAX];  /*fd 번호 → struct file * 매핑 */
+    int fd_next;                    /* 다음에 줄 fd 번호 */
 
 	struct list children;
 	struct semaphore child_wait_sema;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -31,6 +31,10 @@ static void __do_fork (void *);
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
+    for (int i = 0; i < FD_MAX; i++) {
+        current->fd_table[i] = NULL;
+    }
+    current->fd_next = 3;
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -27,14 +27,15 @@ static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
-/* General process initializer for initd and other process. */
+/* 현재 프로세스의 파일 디스크립터 테이블을 초기화한다.
+   표준 입력/출력을 예약하기 위해 다음 할당 fd는 2부터 시작한다. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
     for (int i = 0; i < FD_MAX; i++) {
         current->fd_table[i] = NULL;
     }
-    current->fd_next = 3;
+    current->fd_next = 2;
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -127,18 +127,25 @@ syscall_handler (struct intr_frame *f) {
 	}
 }
 
-/* fd_table에서 fd에 대응하는 file 포인터를 반환한다.
-   fd가 범위를 벗어나거나 할당되지 않은 경우 NULL을 반환한다. */
+/* fd_table에서 일반 파일 fd에 대응하는 file 포인터를 반환한다.
+   표준 입출력 fd와 범위를 벗어난 fd, 할당되지 않은 fd는 NULL을 반환한다. */
 static struct file *
 fd_to_file(int fd) {
+    if (fd < 2 || fd >= FD_MAX) { /* 각 syscall에서 따로 처리하도록 */
+        return NULL;
+    }
     return thread_current()->fd_table[fd];
 }
 
+/* 현재 스레드의 fd_table에서 빈 슬롯을 찾아 file을 등록하고,
+   할당된 fd 번호를 반환한다. 할당할 수 없으면 -1을 반환한다. */
 static int
 fd_alloc(struct file *f) {
     return -1;
 }
 
+/* 현재 스레드의 fd_table에서 fd에 해당하는 file 등록을 해제한다.
+   이후 같은 fd 번호는 다시 할당될 수 있다. */
 static void
 fd_free(int fd) {}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -127,6 +127,21 @@ syscall_handler (struct intr_frame *f) {
 	}
 }
 
+/* fd_table에서 fd에 대응하는 file 포인터를 반환한다.
+   fd가 범위를 벗어나거나 할당되지 않은 경우 NULL을 반환한다. */
+static struct file *
+fd_to_file(int fd) {
+    return thread_current()->fd_table[fd];
+}
+
+static int
+fd_alloc(struct file *f) {
+    return -1;
+}
+
+static void
+fd_free(int fd) {}
+
 static void
 syscall_exit (int status) {
 	printf ("%s: exit(%d)\n", thread_current ()->name, status);


### PR DESCRIPTION
## 요약
- 프로세스 초기화 시 fd_table을 비우고 일반 파일 fd를 2부터 할당하도록 설정했습니다.
- fd_to_file()에서 표준 입출력 fd와 범위 밖 fd를 NULL로 처리하도록 보강했습니다.
- fd_alloc(), fd_free() 구현 의도를 주석으로 정리했습니다.

## 테스트
- 별도 테스트는 실행하지 않았습니다.