### PR TITLE
feat(userprog): wait/exec 동기화와 exec 포인터 검증 구현

### DIFF
--- a/pintos/include/lib/syscall-nr.h
+++ b/pintos/include/lib/syscall-nr.h
@@ -36,6 +36,7 @@ enum {
 
 	SYS_MOUNT,
 	SYS_UMOUNT,
+	SYS_SPAWN,
 };
 
 #endif /* lib/syscall-nr.h */

--- a/pintos/include/lib/user/syscall.h
+++ b/pintos/include/lib/user/syscall.h
@@ -78,4 +78,5 @@ get_fs_disk_write_cnt (void) {
 	return write_cnt;
 }
 
+pid_t spawn (const char *cmdline);
 #endif /* lib/user/syscall.h */

--- a/pintos/lib/user/syscall.c
+++ b/pintos/lib/user/syscall.c
@@ -194,3 +194,8 @@ int
 umount (const char *path) {
 	return syscall1 (SYS_UMOUNT, path);
 }
+
+pid_t
+spawn (const char *cmdline) {
+	return syscall1 (SYS_SPAWN, cmdline);
+}

--- a/pintos/tests/userprog/Make.tests
+++ b/pintos/tests/userprog/Make.tests
@@ -14,6 +14,7 @@ read-normal read-bad-ptr read-boundary \
 read-zero read-stdout read-bad-fd write-normal write-bad-ptr		\
 write-boundary write-zero write-stdin write-bad-fd fork-once fork-multiple	\
 fork-recursive fork-read fork-close fork-boundary exec-once exec-arg \
+spawn-once \
 exec-boundary exec-missing exec-bad-ptr exec-read wait-simple wait-twice		\
 wait-killed wait-bad-pid multi-recurse multi-child-fd       \
 rox-simple rox-child rox-multichild bad-read bad-write bad-read2 bad-write2  \
@@ -97,7 +98,7 @@ tests/userprog/rox-simple_SRC = tests/userprog/rox-simple.c tests/main.c
 tests/userprog/rox-child_SRC = tests/userprog/rox-child.c tests/main.c
 tests/userprog/rox-multichild_SRC = tests/userprog/rox-multichild.c	\
 tests/main.c
-
+tests/userprog/spawn-once_SRC = tests/userprog/spawn-once.c tests/main.c
 tests/userprog/child-simple_SRC = tests/userprog/child-simple.c
 tests/userprog/child-args_SRC = tests/userprog/args.c
 tests/userprog/child-bad_SRC = tests/userprog/child-bad.c tests/main.c
@@ -143,3 +144,4 @@ tests/userprog/wait-killed_PUTFILES += tests/userprog/child-bad
 tests/userprog/rox-child_PUTFILES += tests/userprog/child-rox
 tests/userprog/rox-multichild_PUTFILES += tests/userprog/child-rox
 tests/userprog/exec-read_PUTFILES += tests/userprog/child-read
+tests/userprog/spawn-once_PUTFILES += tests/userprog/child-simple

--- a/pintos/tests/userprog/spawn-once.c
+++ b/pintos/tests/userprog/spawn-once.c
@@ -1,0 +1,13 @@
+#include <syscall.h>
+#include "tests/lib.h"
+#include "tests/main.h"
+
+void
+test_main (void) {
+  pid_t pid;
+
+  msg ("I'm your father");
+
+  pid = spawn ("child-simple");
+  msg ("wait(spawn()) = %d", wait (pid));
+}

--- a/pintos/tests/userprog/spawn-once.ck
+++ b/pintos/tests/userprog/spawn-once.ck
@@ -1,0 +1,14 @@
+# -*- perl -*-
+use strict;
+use warnings;
+use tests::tests;
+check_expected ([<<'EOF']);
+(spawn-once) begin
+(spawn-once) I'm your father
+(child-simple) run
+child-simple: exit(81)
+(spawn-once) wait(spawn()) = 81
+(spawn-once) end
+spawn-once: exit(0)
+EOF
+pass;

--- a/pintos/userprog/.test_config
+++ b/pintos/userprog/.test_config
@@ -114,6 +114,7 @@ priority-donate-chain | --fs-disk=10 | -q  -threads-tests -f run | 'priority-don
 [extra]
 dup2-simple  | --fs-disk=10 -p tests/userprog/dup2/dup2-simple:dup2-simple -p ../../tests/userprog/dup2/sample.txt:sample.txt   | -q -f run | 'dup2-simple'   | tests/userprog/dup2
 dup2-complex | --fs-disk=10 -p tests/userprog/dup2/dup2-complex:dup2-complex -p ../../tests/userprog/dup2/sample.txt:sample.txt | -q   -f run | 'dup2-complex' | tests/userprog/dup2
+spawn-once | --fs-disk=10 -p tests/userprog/spawn-once:spawn-once -p tests/userprog/child-simple:child-simple | -q   -f run | 'spawn-once' | tests/userprog
 
 
 # Total testcases: 97

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -31,6 +31,7 @@ static void syscall_close (int fd);
 static tid_t syscall_fork (const char *thread_name, struct intr_frame *f);
 static void syscall_halt (void);
 static void syscall_invalid (void);
+static tid_t syscall_spawn (const char *cmdline);
 
 /* System call.
  *
@@ -123,6 +124,10 @@ syscall_handler (struct intr_frame *f) {
 			syscall_close ((int) f->R.rdi);
 			break;
 
+		case SYS_SPAWN:
+			f->R.rax = syscall_spawn ((const char *) f->R.rdi);
+			break;
+		
 		default:
 			syscall_invalid ();
 			break;
@@ -139,7 +144,7 @@ syscall_exit (int status) {
 
 static tid_t
 syscall_exec (const char *file) {
-	char *fn_copy = palloc_get_page (0);
+	char *fn_copy = palloc_get_page (0); 
 
 	if (fn_copy == NULL)
 		return -1;
@@ -217,4 +222,9 @@ syscall_halt (void) {
 static void
 syscall_invalid (void) {
 	syscall_exit (-1);
+}
+
+static tid_t
+syscall_spawn (const char *cmdline) {
+	return process_create_initd (cmdline);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -150,15 +150,15 @@ syscall_exit (int status) {
 
 static tid_t
 syscall_exec (const char *file) {
+	check_string(file);
 	char *fn_copy = palloc_get_page (0); 
-
 	if (fn_copy == NULL)
 		return -1;
 
 	strlcpy (fn_copy, file, PGSIZE);
 
 	if (process_exec (fn_copy) < 0)
-		return -1;
+		syscall_exit (-1);
 
 	NOT_REACHED ();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -10,6 +10,8 @@
 #include "intrinsic.h"
 #include "userprog/process.h"
 #include "threads/palloc.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 
 void syscall_entry (void);
@@ -32,6 +34,10 @@ static tid_t syscall_fork (const char *thread_name, struct intr_frame *f);
 static void syscall_halt (void);
 static void syscall_invalid (void);
 static tid_t syscall_spawn (const char *cmdline);
+
+static void check_address (const void *uaddr);
+static void check_string (const char *str);
+static void check_buffer (const void *buffer, unsigned size);
 
 /* System call.
  *
@@ -227,4 +233,30 @@ syscall_invalid (void) {
 static tid_t
 syscall_spawn (const char *cmdline) {
 	return process_create_initd (cmdline);
+}
+
+static void
+check_address (const void *uaddr) {
+	if (uaddr == NULL || !is_user_vaddr (uaddr) || pml4_get_page (thread_current ()->pml4, uaddr) == NULL) {
+		syscall_exit (-1);
+	}
+}
+
+static void
+check_string (const char *str) {
+	check_address (str);
+
+	while (*str != '\0') {
+		str++;
+		check_address (str);
+	}
+}
+
+static void
+check_buffer (const void *buffer, unsigned size) {
+	const char *buf = buffer;
+
+	for (unsigned i = 0; i < size; i++) {
+		check_address (buf + i);
+	}
 }


### PR DESCRIPTION
## 작업 내용

- parent/child wait 동기화를 위한 child_info 구조 추가
- process_create_initd에서 child_info 생성 및 children 리스트 등록
- child exit status 저장 및 process_wait에서 회수 처리
- process_wait 기본 동기화 구현
- SYS_EXEC를 process_exec 흐름에 연결
- child load 성공 여부를 load_sema로 동기화
- exec 인자 user pointer 검증 추가
- process_exec 실패 시 exit(-1) 처리
- 실험용 SYS_SPAWN 및 spawn-once 테스트 추가

## 구현 의도

Project 2에서 user process의 부모-자식 관계를 관리하기 위해 child_info를 도입했습니다.  
부모는 children 리스트에 child_info를 보관하고, 자식은 종료 시 exit_status와 exited 상태를 기록한 뒤 semaphore로 부모를 깨우도록 했습니다.

exec는 새 process 생성이 아니라 현재 process를 새 program으로 교체하는 흐름이므로, SYS_EXEC에서 process_create_initd가 아니라 process_exec를 호출하도록 정리했습니다.  
또한 child process 생성 직후 executable load 성공 여부를 부모가 알 수 있도록 load_success와 load_sema를 추가했습니다.

user pointer 검증을 위해 check_address, check_string, check_buffer helper를 추가했고, 우선 exec 인자 검증과 exec 실패 처리에 적용했습니다.

## 참고

- SYS_SPAWN은 공식 Pintos syscall이 아니라 exec와 process 생성 개념을 구분하기 위한 실험용 기능입니다.
- fork는 아직 구현되지 않아 fork 기반 wait/exec 테스트는 별도 작업이 필요합니다.
- 파일 syscall, fd table, rox, filesys lock은 다른 작업과 병합 후 추가 확인이 필요합니다.

## 확인한 테스트

- args 계열
- exec 기본 계열 일부
- exec-bad-ptr
- exec-missing
- wait 기본 흐름 일부
